### PR TITLE
Scheduler needs to restart any active Job processes after a restart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,5 +42,8 @@ up:
 	@killall epmd > /dev/null || true
 	HOST_IP=$(HOST_IP) docker-compose up --force-recreate --remove-orphans
 
-nebula_inspect:
+inspect:
 	docker-compose exec nebula iex --name debug@127.0.0.1 --hidden -e ":observer.start"
+
+console:
+	docker-compose exec nebula iex --name debug@127.0.0.1 --hidden --remsh "nebula@127.0.0.1"

--- a/services/nebula/lib/nomad/binary.ex
+++ b/services/nebula/lib/nomad/binary.ex
@@ -34,7 +34,7 @@ defmodule Nomad.Binary do
   """
   @spec parse!(pid) :: {:ok, %{String.t => any}} | {:error, any}
   def parse!(pid) do
-    case GenServer.call(pid, :parse) do
+    case GenServer.call(pid, :parse, 10_000) do
       {:ok, json}      -> {:ok, json}
       {:error, output} -> {:error, output}
     end

--- a/services/nebula/lib/scheduler/job.ex
+++ b/services/nebula/lib/scheduler/job.ex
@@ -67,13 +67,14 @@ defmodule Nebula.Scheduler.Job do
   Create new child process for the given Job, registering it's process with the
   scheduler process.
   """
-  def create(job) do
-    case Nebula.Scheduler.start_job(job.id) do
+  def create(job) when is_map(job), do: create(job.id)
+  def create(id) do
+    case Nebula.Scheduler.JobPool.start_job(id) do
       {:ok, child} ->
         GenServer.cast(child, :start)
         {:ok, child}
       {:error, error} ->
-        Logger.error "[scheduler] Failed to create job [id:#{job.id}]"
+        Logger.error "[scheduler] Failed to create job [id:#{id}]"
         {:error, error}
     end
   end

--- a/services/nebula/lib/scheduler/job_pool.ex
+++ b/services/nebula/lib/scheduler/job_pool.ex
@@ -1,0 +1,21 @@
+defmodule Nebula.Scheduler.JobPool do
+  use Supervisor
+  alias Nebula.Scheduler.Job
+
+  def start_link do
+    Supervisor.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def init(_) do
+    supervise([worker(Job, [])], strategy: :simple_one_for_one)
+  end
+
+  def start_job(id) do
+    Supervisor.start_child(__MODULE__, [id])
+  end
+
+  def jobs do
+    # TODO this does not work
+    Supervisor.count_children(__MODULE__)
+  end
+end

--- a/services/nebula/lib/scheduler/loader.ex
+++ b/services/nebula/lib/scheduler/loader.ex
@@ -1,0 +1,37 @@
+defmodule Nebula.Scheduler.Loader do
+  use GenServer
+  require Logger
+  import Ecto.Query
+  alias Nebula.Scheduler.Job
+
+  def start_link do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def init(_) do
+    Process.send_after(self(), :started, 0)
+    {:ok, []}
+  end
+
+  def handle_info(:started, []) do
+    start_missing_jobs
+    {:noreply, []}
+  end
+
+  @doc """
+  Potentially if the Nebula app reboots or shuts down or whatever, there can be
+  a case where Nomad Jobs are still in-flight. In this case we should re-start
+  the Nebula jobs to track the status of them.
+  This method will start job processes for jobs that are not 'complete'.
+  """
+  def start_missing_jobs do
+    Logger.info "[scheduler] Checking for missing Job processes after start..."
+    Nebula.Job
+    |> join(:left, [job], deploy in assoc(job, :deploy))
+    |> where([_, deploy], deploy.state != ^Nebula.Deploy.states.complete)
+    |> select([job, _], job.id)
+    |> Nebula.Repo.all
+    |> Enum.filter(fn(id) -> Job.get(id) == :undefined end)
+    |> Enum.map(&Job.create/1)
+  end
+end

--- a/services/nebula/lib/scheduler/reaper.ex
+++ b/services/nebula/lib/scheduler/reaper.ex
@@ -8,7 +8,7 @@ defmodule Nebula.Scheduler.Reaper do
   alias Ecto.Changeset
 
   def start_link do
-    GenServer.start_link(__MODULE__, [], name: :reaper)
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
 
   def init(jobs) do
@@ -30,9 +30,10 @@ defmodule Nebula.Scheduler.Reaper do
   end
 
   defp expired_deploys do
-    query = from d in Nebula.Deploy,
-            where: d.expire_at < ^DateTime.now and d.state == ^Deploy.states.running,
-            select: d
-    Nebula.Repo.all(query)
+    Nebula.Repo.all(
+      from d in Nebula.Deploy,
+      where: d.expire_at < ^DateTime.now and d.state == ^Deploy.states.running,
+      select: d
+    )
   end
 end

--- a/services/nebula/lib/scheduler/scheduler.ex
+++ b/services/nebula/lib/scheduler/scheduler.ex
@@ -1,22 +1,20 @@
 defmodule Nebula.Scheduler do
   use Supervisor
   require Logger
+  alias Nebula.Scheduler.JobPool
+  alias Nebula.Scheduler.Loader
 
   def start_link do
     Logger.info "[scheduler] Started scheduler process"
-    Supervisor.start_link(__MODULE__, [], name: :scheduler)
+    Supervisor.start_link(__MODULE__, [], name: __MODULE__)
   end
 
   def init(_) do
-    supervise([worker(Nebula.Scheduler.Job, [])], strategy: :simple_one_for_one)
-  end
+    children = [
+      worker(JobPool, []),
+      worker(Loader, [])
+    ]
 
-  def start_job(id) do
-    Supervisor.start_child(:scheduler, [id])
-  end
-
-  def jobs do
-    # TODO this does not work
-    Supervisor.count_children(:scheduler)
+    supervise(children, strategy: :one_for_one)
   end
 end

--- a/services/nebula/web/models/deploy.ex
+++ b/services/nebula/web/models/deploy.ex
@@ -5,7 +5,7 @@ defmodule Nebula.Deploy do
     defstruct accepted: "accepted",
               pending: "pending",
               running: "running",
-              dead: "dead"
+              complete: "complete"
   end
 
   schema "deploys" do
@@ -44,5 +44,10 @@ defmodule Nebula.Deploy do
       "http://",
       deploy.slug <> "." <> Application.get_env(:nebula, :domain_name)
     ])
+  end
+
+  def find_by_state(q, ""), do: q
+  def find_by_state(q, state) do
+    from deploy in q, where: deploy.state == ^state
   end
 end


### PR DESCRIPTION
Currently if the nebula server reboots or shuts down for any reason all the Job processes will be killed and at the moment not restarted when the rest of the app boots.

I think this could be fixed just by finding all deploys in the DB that are in theory still active and starting Job procesess for all of them. These processes should then go and check with Nomad what the actual status of the Nomad job is and either terminate or start monitoring.
